### PR TITLE
Do not execute the following success steps once pipeline has failed

### DIFF
--- a/src/main/java/io/vlingo/xoom/common/completes/FutureCompletes.java
+++ b/src/main/java/io/vlingo/xoom/common/completes/FutureCompletes.java
@@ -515,7 +515,7 @@ public class FutureCompletes<T> implements Completes<T> {
             return;
           }
 
-          if (previous.hasFailed() && !previous.handlesFailure) {
+          if (previous.hasFailed()) {
             fail(previous.failureValue(), previous.isTimedOut());
             if (!handlesFailure) {
               return;
@@ -561,19 +561,19 @@ public class FutureCompletes<T> implements Completes<T> {
             return (O) value;
           }
 
-          if (previous.hasFailed() && !previous.handlesFailure) {
+          if (previous.hasFailed() && !handlesFailure) {
             fail(previous.failureValue(), previous.isTimedOut());
-            if (!handlesFailure) {
-              return (O) previous.failureValue();
-            }
-          } else if (isFailureValue(value)) {
+            return (O) previous.failureValue();
+          } else if (isFailureValue(value) && !handlesFailure) {
             fail(failureValue(), isTimedOut());
-            if (!handlesFailure) {
-              return (O) failureValue();
-            }
+            return (O) failureValue();
           }
 
-          return userFunction.apply(value);
+          O outcome = userFunction.apply(value);
+          if (handlesFailure) {
+            fail((T) outcome, previous.isTimedOut());
+          }
+          return outcome;
         } catch (Exception cause) {
           fail(failureValue(), isTimedOut());
           throw cause;


### PR DESCRIPTION
Following @VaughnVernon's comment: https://github.com/vlingo/xoom-common/pull/44#issuecomment-898066969

> @jakzal I think that the original intention was that a failure handled by an otherwise() would terminate the pipeline. However, I don't disagree that it should be possible to continue the pipeline if otherwise() actually recovers the failure.

> Given that preexisting pipelines terminate on failure should (or would hopefully) not cause problems because most/all purposely short circuit by producing a final outcome. For example, 404 or 500 on some HTTP response.

I agree we shouldn't continue the pipeline once a failure occurs, but the following otherwise* functions and consumers should still be executed.